### PR TITLE
[7.0] Add cleanup scripts for postgresql

### DIFF
--- a/7.0.0/README.md
+++ b/7.0.0/README.md
@@ -24,9 +24,9 @@ The script allows for specifying shared and identity databases through separate 
 
 ### Configuration Section
 ```bash
-# Supported DB types: h2, mssql, mysql
-SHARED_DB_TYPE="mysql"     # can be h2, mssql, or mysql
-IDENTITY_DB_TYPE="mysql"   # can be h2, mssql, or mysql
+# Supported DB types: h2, mssql, mysql, postgresql
+SHARED_DB_TYPE="mysql"     # can be h2, mssql, mysql, or postgresql
+IDENTITY_DB_TYPE="mysql"   # can be h2, mssql, mysql, or postgresql
 
 # Shared database configurations
 <Refer below sections on how to fill this information based on the DB type>
@@ -43,7 +43,7 @@ H2_JAR_PATH="/path/to/h2-2.2.220.jar" # This is only needed if the the database 
 
 ### Explanation of Variables
 
-- **SHARED_DB_TYPE/IDENTITY_DB_TYPE**: Define the database type (`h2`, `mssql`, `mysql`).
+- **SHARED_DB_TYPE/IDENTITY_DB_TYPE**: Define the database type (`h2`, `mssql`, `mysql`, `postgresql`).
 - **SHARED_DB_* / IDENTITY_DB_***: Define respective hosts, ports, database names, users, passwords, and log directories as arrays. Each index corresponds to one database instance.
 - **BATCH_SIZE**: Number of organizations processed in each batch.
 - **BATCH_WAIT_TIME**: Wait time between batch executions (in milliseconds).
@@ -180,6 +180,60 @@ brew services start mysql
      ```
 
 3. Update `H2_JAR_PATH` (only for h2) with the correct file paths.
+
+---
+
+#### PostgreSQL
+---
+
+1. First you need to install psql client
+- **Linux:**
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install postgresql-client -y
+```
+- **Mac:**
+```bash
+brew install libpq
+brew link --force libpq
+```
+
+2. Then update the DB configs in the `cleanup.sh` as follows,
+
+- **Single Instance:**
+    ```bash
+    # Shared database configurations
+    SHARED_DB_HOSTS=("127.0.0.1")
+    SHARED_DB_PORTS=("5432")
+    SHARED_DB_NAMES=("wso2shared_db")
+    SHARED_DB_USERS=("postgres")
+    SHARED_DB_PASSWORDS=("yourpassword")
+    SHARED_DB_LOG_DIRS=("path/to/log")
+
+    # Identity database configurations
+    IDENTITY_DB_HOSTS=("127.0.0.1")
+    IDENTITY_DB_PORTS=("5432")
+    IDENTITY_DB_NAMES=("wso2identity_db")
+    IDENTITY_DB_USERS=("postgres")
+    IDENTITY_DB_PASSWORDS=("yourpassword")
+    IDENTITY_DB_LOG_DIRS=("path/to/log")
+    ```
+- **Multiple Instances:** (Refer this if you have setup the database according to [Separate Databases for Clustering](https://is.docs.wso2.com/en/latest/deploy/set-up-separate-databases-for-clustering/))
+    ```bash
+    SHARED_DB_HOSTS=("127.0.0.1" "127.0.0.1")
+    SHARED_DB_PORTS=("5432" "5432")
+    SHARED_DB_NAMES=("wso2shared_db_1" "wso2shared_db_2")
+    SHARED_DB_USERS=("postgres" "postgres")
+    SHARED_DB_PASSWORDS=("yourpassword1" "yourpassword2")
+    SHARED_DB_LOG_DIRS=("/var/log/shared1" "/var/log/shared2") # If there are 2 DBs, then 2 paths are needed for logging
+
+    IDENTITY_DB_HOSTS=("127.0.0.1" "127.0.0.1")
+    IDENTITY_DB_PORTS=("5432" "5432")
+    IDENTITY_DB_NAMES=("wso2identity_db_1" "wso2identity_db_2")
+    IDENTITY_DB_USERS=("postgres" "postgres")
+    IDENTITY_DB_PASSWORDS=("yourpassword" "yourpassword")
+    IDENTITY_DB_LOG_DIRS=("path/to/log_1" "path/to/log_2")
+    ```
 
 ---
 

--- a/7.0.0/README.md
+++ b/7.0.0/README.md
@@ -1,7 +1,6 @@
 # B2B Deleted Organizations Resource Cleanup Script - Documentation
 
-This document provides detailed instructions on setting up and executing the database cleanup script. The script is designed to handle shared and identity databases in H2, MSSQL, or MySQL. It supports configurations for multiple databases as arrays, allowing flexible setups such as clustering.
-
+This document provides detailed instructions on setting up and executing the database cleanup script. The script is designed to handle shared and identity databases in H2, MSSQL, MySQL or PostgreSQL. It supports configurations for multiple databases as arrays, allowing flexible setups such as clustering.
 
 ## Prerequisites
 
@@ -9,6 +8,7 @@ This document provides detailed instructions on setting up and executing the dat
    - H2
    - MSSQL
    - MySQL
+   - PostgreSQL
 
 2. **Required Tools**:
    - Bash shell

--- a/7.0.0/postgresql/delete_um_tenant.sh
+++ b/7.0.0/postgresql/delete_um_tenant.sh
@@ -13,6 +13,12 @@ LOG_DIR="$8"
 # Export PostgreSQL password to suppress password warnings
 export PGPASSWORD="$DB_PASSWORD"
 
+cleanup() {
+  unset PGPASSWORD
+}
+
+trap cleanup EXIT
+
 SUMMARY_FILE="$LOG_DIR/um_tenant_deletion_summary.log"
 FAILED_LOG_DIR="$LOG_DIR/failed_deletions"
 
@@ -63,6 +69,13 @@ fi
 
 echo "Starting UM_TENANT deletion process..."
 for TENANT_ID in $COMMON_TENANTS; do
+  TENANT_ID=$(echo "$TENANT_ID" | xargs)
+
+  if [[ ! "$TENANT_ID" =~ ^[0-9]+$ ]]; then
+    echo "Skipping invalid TENANT_ID=$TENANT_ID"
+    continue
+  fi
+
   echo "Processing TENANT_ID=$TENANT_ID"
 
   # Generate the delete procedure
@@ -81,8 +94,5 @@ for TENANT_ID in $COMMON_TENANTS; do
     echo "Failed to delete UM_TENANT entry for TENANT_ID=$TENANT_ID. Check log: $FAILED_LOG" | tee -a "$SUMMARY_FILE"
   fi
 done
-
-# Unset PGPASSWORD to avoid leaving it in the environment
-unset PGPASSWORD
 
 echo "UM_TENANT deletion process completed. Summary available at $SUMMARY_FILE."

--- a/7.0.0/postgresql/delete_um_tenant.sh
+++ b/7.0.0/postgresql/delete_um_tenant.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Arguments: DB_HOST DB_PORT DB_NAME DB_USER DB_PASSWORD SHARED_DB_SUCCESS_FILE IDENTITY_DB_SUCCESS_FILE LOG_DIR
+DB_HOST="$1"
+DB_PORT="$2"
+DB_NAME="$3"
+DB_USER="$4"
+DB_PASSWORD="$5"
+SHARED_DB_SUCCESS_FILE="$6"
+IDENTITY_DB_SUCCESS_FILE="$7"
+LOG_DIR="$8"
+
+# Export PostgreSQL password to suppress password warnings
+export PGPASSWORD="$DB_PASSWORD"
+
+SUMMARY_FILE="$LOG_DIR/um_tenant_deletion_summary.log"
+FAILED_LOG_DIR="$LOG_DIR/failed_deletions"
+
+# Create necessary directories
+mkdir -p "$LOG_DIR"
+mkdir -p "$FAILED_LOG_DIR"
+
+# Initialize summary log
+echo "Summary of UM_TENANT Deletions:" > "$SUMMARY_FILE"
+
+# Check if the input files exist
+if [[ ! -f "$SHARED_DB_SUCCESS_FILE" ]]; then
+  echo "Shared DB success file not found: $SHARED_DB_SUCCESS_FILE"
+  exit 1
+fi
+
+if [[ ! -f "$IDENTITY_DB_SUCCESS_FILE" ]]; then
+  echo "Identity DB success file not found: $IDENTITY_DB_SUCCESS_FILE"
+  exit 1
+fi
+
+# Read tenant IDs from both files (excluding header)
+echo "Reading tenant IDs from shared DB and identity DB success files..."
+SHARED_TENANTS=$(tail -n +2 "$SHARED_DB_SUCCESS_FILE" | sort)
+IDENTITY_TENANTS=$(tail -n +2 "$IDENTITY_DB_SUCCESS_FILE" | sort)
+
+# Find mismatched tenant IDs
+SHARED_ONLY=$(comm -23 <(echo "$SHARED_TENANTS") <(echo "$IDENTITY_TENANTS"))
+IDENTITY_ONLY=$(comm -13 <(echo "$SHARED_TENANTS") <(echo "$IDENTITY_TENANTS"))
+
+# Check for mismatches
+if [[ -n "$SHARED_ONLY" || -n "$IDENTITY_ONLY" ]]; then
+  echo "Mismatch detected between shared DB and identity DB success files."
+  echo "Tenant IDs present only in shared DB:" >> "$SUMMARY_FILE"
+  echo "$SHARED_ONLY" >> "$SUMMARY_FILE"
+  echo "Tenant IDs present only in identity DB:" >> "$SUMMARY_FILE"
+  echo "$IDENTITY_ONLY" >> "$SUMMARY_FILE"
+  exit 2
+fi
+
+# Find common tenant IDs
+COMMON_TENANTS=$(comm -12 <(echo "$SHARED_TENANTS") <(echo "$IDENTITY_TENANTS"))
+
+if [[ -z "$COMMON_TENANTS" ]]; then
+  echo "No common tenant IDs found between shared DB and identity DB."
+  exit 0
+fi
+
+echo "Starting UM_TENANT deletion process..."
+for TENANT_ID in $COMMON_TENANTS; do
+  echo "Processing TENANT_ID=$TENANT_ID"
+
+  # Generate the delete procedure
+  DELETE_PROCEDURE="DELETE FROM UM_TENANT WHERE UM_ID = ${TENANT_ID};"
+
+  # Execute the delete procedure
+  echo "Executing deletion procedure for TENANT_ID=$TENANT_ID..."
+  psql -h "$DB_HOST" -p "$DB_PORT" -d "$DB_NAME" -U "$DB_USER" -c "$DELETE_PROCEDURE" -q > /dev/null 2>&1
+
+  # Check if the execution was successful
+  if [[ $? -eq 0 ]]; then
+    echo "Successfully deleted UM_TENANT entry for TENANT_ID=$TENANT_ID." | tee -a "$SUMMARY_FILE"
+  else
+    FAILED_LOG="$FAILED_LOG_DIR/failed_tenant_${TENANT_ID}.log"
+    echo "$DELETE_PROCEDURE" > "$FAILED_LOG"
+    echo "Failed to delete UM_TENANT entry for TENANT_ID=$TENANT_ID. Check log: $FAILED_LOG" | tee -a "$SUMMARY_FILE"
+  fi
+done
+
+# Unset PGPASSWORD to avoid leaving it in the environment
+unset PGPASSWORD
+
+echo "UM_TENANT deletion process completed. Summary available at $SUMMARY_FILE."

--- a/7.0.0/postgresql/identity_db_cleanup.sh
+++ b/7.0.0/postgresql/identity_db_cleanup.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+# Arguments: DB_HOST DB_PORT DB_NAME DB_USER DB_PASSWORD EXPORT_FILE LOG_DIR
+DB_HOST="$1"
+DB_PORT="$2"
+DB_NAME="$3"
+DB_USER="$4"
+DB_PASSWORD="$5"
+EXPORT_FILE="$6"
+LOG_DIR="$7"
+
+# Export PostgreSQL password to suppress password warnings
+export PGPASSWORD="$DB_PASSWORD"
+
+SUMMARY_FILE="$LOG_DIR/summary.log"
+SUCCESSFUL_DELETIONS_FILE="$LOG_DIR/successful_deletions.csv"
+
+# Create necessary directories
+mkdir -p "$LOG_DIR"
+
+# Initialize summary log and successful deletions file
+echo "Summary of Deletions:" > "$SUMMARY_FILE"
+echo "TENANT_ID" > "$SUCCESSFUL_DELETIONS_FILE"
+
+# Predefined table deletion order
+TABLE_LIST=(
+  "IDN_OAUTH_CONSUMER_APPS"
+  "IDN_OAUTH2_SCOPE"
+  "SP_APP"
+  "IDP"
+  "IDN_CLAIM_DIALECT"
+  "IDN_CONFIG_RESOURCE"
+  "IDN_REMOTE_FETCH_CONFIG"
+  "IDN_CORS_ORIGIN"
+  "IDN_SECRET"
+  "API_RESOURCE"
+  "IDN_AUTH_USER"
+  "IDN_AUTH_SESSION_STORE"
+  "IDN_AUTH_TEMP_SESSION_STORE"
+  "IDN_AUTH_WAIT_STATUS"
+  "IDN_SCIM_GROUP"
+  "IDN_OPENID_REMEMBER_ME"
+  "IDN_OPENID_USER_RPS"
+  "IDN_OPENID_ASSOCIATIONS"
+  "IDN_IDENTITY_USER_DATA"
+  "IDN_IDENTITY_META_DATA"
+  "IDN_THRIFT_SESSION"
+  "FIDO_DEVICE_STORE"
+  "FIDO2_DEVICE_STORE"
+  "IDN_USER_ACCOUNT_ASSOCIATION"
+  "IDN_RECOVERY_DATA"
+  "IDN_PASSWORD_HISTORY_DATA"
+  "IDN_OIDC_JTI"
+  "IDN_OAUTH2_USER_CONSENT"
+  "IDN_USER_FUNCTIONALITY_MAPPING"
+  "IDN_USER_FUNCTIONALITY_PROPERTY"
+  "IDN_FUNCTION_LIBRARY"
+  "IDVP"
+  "IDN_ORG_USER_INVITATION"
+  "IDN_OAUTH2_ACCESS_TOKEN_AUDIT"
+  "SP_TEMPLATE"
+  "IDN_CERTIFICATE"
+)
+
+# Validate export file
+if [[ ! -f "$EXPORT_FILE" || ! -s "$EXPORT_FILE" ]]; then
+  echo "Export file is missing or empty. Exiting."
+  exit 1
+fi
+
+echo "Fetching available tables from PostgreSQL database..."
+# Fetch available tables from PostgreSQL
+AVAILABLE_TABLES=$(psql -h "$DB_HOST" -p "$DB_PORT" -d "$DB_NAME" -U "$DB_USER" -t -c "SELECT tablename FROM pg_tables WHERE schemaname = 'public';")
+
+if [[ $? -ne 0 ]]; then
+  echo "Failed to fetch available tables. Please check database connection and credentials."
+  exit 1
+fi
+
+# Filter TABLE_LIST to include only tables that exist in AVAILABLE_TABLES
+DELETE_ORDER=()
+for table in "${TABLE_LIST[@]}"; do
+  if echo "$AVAILABLE_TABLES" | grep -qw "$table"; then
+    DELETE_ORDER+=("$table")
+  fi
+done
+
+echo "Tables to delete in order: ${DELETE_ORDER[*]}"
+
+echo "Starting data deletion process..."
+while IFS=',' read -r TENANT_ID ORG_UUID; do
+  # Trim and sanitize TENANT_ID, ORG_UUID
+  TENANT_ID=$(echo "$TENANT_ID" | xargs | sed 's/[^a-zA-Z0-9-]//g')
+  ORG_UUID=$(echo "$ORG_UUID" | xargs | sed 's/[^a-zA-Z0-9-]//g')
+
+  if [[ -n "$TENANT_ID" && -n "$ORG_UUID" ]]; then
+    echo "Processing TENANT_ID=$TENANT_ID, ORG_UUID=$ORG_UUID"
+
+    # Generate the delete procedure dynamically
+    DELETE_PROCEDURE=""
+    for table in "${DELETE_ORDER[@]}"; do
+      if [[ "$table" == "IDN_ORG_USER_INVITATION" ]]; then
+        DELETE_PROCEDURE+="DELETE FROM $table WHERE INVITED_ORG_ID = '$ORG_UUID';"
+      else
+        DELETE_PROCEDURE+="DELETE FROM $table WHERE TENANT_ID = $TENANT_ID;"
+      fi
+    done
+
+    # Execute the delete procedure
+    echo "Executing deletion procedure on identity database for TENANT_ID=$TENANT_ID..."
+    psql -h "$DB_HOST" -p "$DB_PORT" -d "$DB_NAME" -U "$DB_USER" -c "$DELETE_PROCEDURE" -q > /dev/null 2>&1
+
+    # Check if the execution was successful
+    if [[ $? -eq 0 ]]; then
+      echo "Resources deleted for tenant ID $TENANT_ID with org ID $ORG_UUID." | tee -a "$SUMMARY_FILE"
+      echo "$TENANT_ID" >> "$SUCCESSFUL_DELETIONS_FILE"
+    else
+      FAILED_LOG="$LOG_DIR/failed_tenant_${TENANT_ID}.log"
+      echo "$DELETE_PROCEDURE" > "$FAILED_LOG"
+      echo "Failed to process tenant ID $TENANT_ID with org ID $ORG_UUID. Check log: $FAILED_LOG" | tee -a "$SUMMARY_FILE"
+    fi
+  else
+    echo "Skipping invalid or empty line: TENANT_ID=$TENANT_ID, ORG_UUID=$ORG_UUID"
+  fi
+done < "$EXPORT_FILE"
+
+echo "Data deletion process completed. Summary available at $SUMMARY_FILE."
+
+# Unset PGPASSWORD to avoid leaving it in the environment
+unset PGPASSWORD

--- a/7.0.0/postgresql/identity_db_cleanup.sh
+++ b/7.0.0/postgresql/identity_db_cleanup.sh
@@ -12,6 +12,12 @@ LOG_DIR="$7"
 # Export PostgreSQL password to suppress password warnings
 export PGPASSWORD="$DB_PASSWORD"
 
+cleanup() {
+  unset PGPASSWORD
+}
+
+trap cleanup EXIT
+
 SUMMARY_FILE="$LOG_DIR/summary.log"
 SUCCESSFUL_DELETIONS_FILE="$LOG_DIR/successful_deletions.csv"
 
@@ -80,7 +86,7 @@ fi
 # Filter TABLE_LIST to include only tables that exist in AVAILABLE_TABLES
 DELETE_ORDER=()
 for table in "${TABLE_LIST[@]}"; do
-  if echo "$AVAILABLE_TABLES" | grep -qw "$table"; then
+  if echo "$AVAILABLE_TABLES" | grep -qiw "$table"; then
     DELETE_ORDER+=("$table")
   fi
 done
@@ -108,7 +114,7 @@ while IFS=',' read -r TENANT_ID ORG_UUID; do
 
     # Execute the delete procedure
     echo "Executing deletion procedure on identity database for TENANT_ID=$TENANT_ID..."
-    psql -h "$DB_HOST" -p "$DB_PORT" -d "$DB_NAME" -U "$DB_USER" -c "$DELETE_PROCEDURE" -q > /dev/null 2>&1
+    PSQL_ERROR=$(psql -h "$DB_HOST" -p "$DB_PORT" -d "$DB_NAME" -U "$DB_USER" -c "$DELETE_PROCEDURE" -q 2>&1 > /dev/null)
 
     # Check if the execution was successful
     if [[ $? -eq 0 ]]; then
@@ -117,6 +123,9 @@ while IFS=',' read -r TENANT_ID ORG_UUID; do
     else
       FAILED_LOG="$LOG_DIR/failed_tenant_${TENANT_ID}.log"
       echo "$DELETE_PROCEDURE" > "$FAILED_LOG"
+      if [[ -n "$PSQL_ERROR" ]]; then
+        echo "$PSQL_ERROR" >> "$FAILED_LOG"
+      fi
       echo "Failed to process tenant ID $TENANT_ID with org ID $ORG_UUID. Check log: $FAILED_LOG" | tee -a "$SUMMARY_FILE"
     fi
   else
@@ -125,6 +134,3 @@ while IFS=',' read -r TENANT_ID ORG_UUID; do
 done < "$EXPORT_FILE"
 
 echo "Data deletion process completed. Summary available at $SUMMARY_FILE."
-
-# Unset PGPASSWORD to avoid leaving it in the environment
-unset PGPASSWORD

--- a/7.0.0/postgresql/org_data_fetch.sh
+++ b/7.0.0/postgresql/org_data_fetch.sh
@@ -24,6 +24,11 @@ echo "DB_NAME: $DB_NAME"
 echo "BATCH_SIZE: $BATCH_SIZE"
 echo "EXPORT_FILE: $EXPORT_FILE"
 
+if [[ ! "$BATCH_SIZE" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Invalid BATCH_SIZE: $BATCH_SIZE. It must be a positive integer."
+  exit 1
+fi
+
 # Query to fetch N deleted organizations
 FETCH_QUERY="
 SELECT UM_TENANT.UM_ID AS TENANT_ID, UM_TENANT.UM_ORG_UUID AS ORG_UUID

--- a/7.0.0/postgresql/org_data_fetch.sh
+++ b/7.0.0/postgresql/org_data_fetch.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Arguments: host port db_name user password batch_size export_file
+DB_HOST="$1"
+DB_PORT="$2"
+DB_NAME="$3"
+DB_USER="$4"
+DB_PASSWORD="$5"
+BATCH_SIZE="$6"
+EXPORT_FILE="$7"
+
+export PGPASSWORD="$DB_PASSWORD"
+
+# Display configuration
+echo "DB_SERVER: ${DB_HOST}:${DB_PORT}"
+echo "DB_NAME: $DB_NAME"
+echo "BATCH_SIZE: $BATCH_SIZE"
+echo "EXPORT_FILE: $EXPORT_FILE"
+
+# Query to fetch N deleted organizations
+FETCH_QUERY="
+SELECT UM_TENANT.UM_ID AS TENANT_ID, UM_TENANT.UM_ORG_UUID AS ORG_UUID
+FROM UM_TENANT
+LEFT JOIN UM_ORG ON UM_TENANT.UM_ORG_UUID = UM_ORG.UM_ID
+WHERE UM_TENANT.UM_ACTIVE = 0 AND UM_ORG.UM_ID IS NULL
+ORDER BY UM_TENANT.UM_CREATED_DATE DESC
+LIMIT $BATCH_SIZE;
+"
+
+echo "Fetching tenant IDs and organization UUIDs from PostgreSQL database..."
+
+# Temporary file to store raw output
+RAW_OUTPUT="/tmp/raw_output.log"
+
+# Execute the query and capture output in a raw format
+psql -h "$DB_HOST" -p "$DB_PORT" -d "$DB_NAME" -U "$DB_USER" -c "$FETCH_QUERY" -t -A -F $'\t' 2>error.log > "$RAW_OUTPUT"
+
+# Check for errors
+if [[ $? -ne 0 ]]; then
+  echo "Failed to fetch data. PostgreSQL error log:"
+  cat error.log
+  exit 1
+fi
+
+> "$EXPORT_FILE" # Clear previous data.
+if [[ ! -s "$RAW_OUTPUT" ]]; then
+  echo "Query executed successfully but no data returned. Exiting with success."
+  > "$EXPORT_FILE"
+  exit 0
+fi
+
+# Add header to the output file
+# echo "TENANT_ID,ORG_UUID" > "$EXPORT_FILE"
+
+# Process raw output: Convert tabs to commas and write to the final file
+while IFS=$'\t' read -r TENANT_ID ORG_UUID; do
+  # Skip empty lines
+  [[ -z "$TENANT_ID" ]] && continue
+
+  # Write processed line to the export file
+  echo "$TENANT_ID,$ORG_UUID" >> "$EXPORT_FILE"
+done < "$RAW_OUTPUT"
+
+# Clean up temporary raw output file
+rm -f "$RAW_OUTPUT"
+
+# Check if the export file contains more than just the header
+if [[ $(wc -l < "$EXPORT_FILE") -le 1 ]]; then
+  echo "Query executed successfully but no data returned. Exiting with success."
+  exit 0
+else
+  echo "Data exported to $EXPORT_FILE successfully in CSV format."
+fi
+
+# Unset PGPASSWORD to avoid leaving it in the environment.
+unset PGPASSWORD

--- a/7.0.0/postgresql/org_data_fetch.sh
+++ b/7.0.0/postgresql/org_data_fetch.sh
@@ -11,6 +11,13 @@ EXPORT_FILE="$7"
 
 export PGPASSWORD="$DB_PASSWORD"
 
+cleanup() {
+  unset PGPASSWORD
+  [[ -n "$RAW_OUTPUT" ]] && rm -f "$RAW_OUTPUT"
+}
+
+trap cleanup EXIT
+
 # Display configuration
 echo "DB_SERVER: ${DB_HOST}:${DB_PORT}"
 echo "DB_NAME: $DB_NAME"
@@ -22,7 +29,7 @@ FETCH_QUERY="
 SELECT UM_TENANT.UM_ID AS TENANT_ID, UM_TENANT.UM_ORG_UUID AS ORG_UUID
 FROM UM_TENANT
 LEFT JOIN UM_ORG ON UM_TENANT.UM_ORG_UUID = UM_ORG.UM_ID
-WHERE UM_TENANT.UM_ACTIVE = 0 AND UM_ORG.UM_ID IS NULL
+WHERE UM_TENANT.UM_ACTIVE = FALSE AND UM_ORG.UM_ID IS NULL
 ORDER BY UM_TENANT.UM_CREATED_DATE DESC
 LIMIT $BATCH_SIZE;
 "
@@ -30,7 +37,7 @@ LIMIT $BATCH_SIZE;
 echo "Fetching tenant IDs and organization UUIDs from PostgreSQL database..."
 
 # Temporary file to store raw output
-RAW_OUTPUT="/tmp/raw_output.log"
+RAW_OUTPUT=$(mktemp)
 
 # Execute the query and capture output in a raw format
 psql -h "$DB_HOST" -p "$DB_PORT" -d "$DB_NAME" -U "$DB_USER" -c "$FETCH_QUERY" -t -A -F $'\t' 2>error.log > "$RAW_OUTPUT"
@@ -42,10 +49,10 @@ if [[ $? -ne 0 ]]; then
   exit 1
 fi
 
-> "$EXPORT_FILE" # Clear previous data.
+: > "$EXPORT_FILE" # Clear previous data.
 if [[ ! -s "$RAW_OUTPUT" ]]; then
   echo "Query executed successfully but no data returned. Exiting with success."
-  > "$EXPORT_FILE"
+  : > "$EXPORT_FILE"
   exit 0
 fi
 
@@ -61,16 +68,10 @@ while IFS=$'\t' read -r TENANT_ID ORG_UUID; do
   echo "$TENANT_ID,$ORG_UUID" >> "$EXPORT_FILE"
 done < "$RAW_OUTPUT"
 
-# Clean up temporary raw output file
-rm -f "$RAW_OUTPUT"
-
 # Check if the export file contains more than just the header
-if [[ $(wc -l < "$EXPORT_FILE") -le 1 ]]; then
+if [[ $(wc -l < "$EXPORT_FILE") -lt 1 ]]; then
   echo "Query executed successfully but no data returned. Exiting with success."
   exit 0
 else
   echo "Data exported to $EXPORT_FILE successfully in CSV format."
 fi
-
-# Unset PGPASSWORD to avoid leaving it in the environment.
-unset PGPASSWORD

--- a/7.0.0/postgresql/shared_db_cleanup.sh
+++ b/7.0.0/postgresql/shared_db_cleanup.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+# Arguments: DB_HOST DB_PORT DB_NAME DB_USER DB_PASSWORD EXPORT_FILE LOG_DIR
+DB_HOST="$1"
+DB_PORT="$2"
+DB_NAME="$3"
+DB_USER="$4"
+DB_PASSWORD="$5"
+EXPORT_FILE="$6"
+LOG_DIR="$7"
+
+# Export PostgreSQL password to suppress password warnings
+export PGPASSWORD="$DB_PASSWORD"
+
+SUMMARY_FILE="$LOG_DIR/summary.log"
+SUCCESSFUL_DELETIONS_FILE="$LOG_DIR/successful_deletions.csv"
+
+# Create a directory for query logs
+mkdir -p "$LOG_DIR"
+
+# Initialize summary log and successful deletions file
+echo "Summary of Deletions:" > "$SUMMARY_FILE"
+echo "TENANT_ID" > "$SUCCESSFUL_DELETIONS_FILE"
+
+# Predefined table deletion order
+TABLE_LIST=(
+  "REG_RESOURCE_COMMENT"
+  "REG_RESOURCE_RATING"
+  "REG_RESOURCE_TAG"
+  "REG_RESOURCE_PROPERTY"
+  "REG_RESOURCE_HISTORY"
+  "REG_SNAPSHOT"
+  "REG_RESOURCE"
+  "REG_COMMENT"
+  "REG_RATING"
+  "REG_TAG"
+  "REG_PROPERTY"
+  "REG_ASSOCIATION"
+  "REG_PATH"
+  "REG_CONTENT_HISTORY"
+  "REG_CONTENT"
+  "REG_LOG"
+  "UM_USER_ATTRIBUTE"
+  "UM_USER"
+  "UM_ROLE"
+  "UM_HYBRID_ROLE"
+  "UM_SYSTEM_USER"
+  "UM_SYSTEM_ROLE"
+  "UM_PERMISSION"
+  "UM_DIALECT"
+  "UM_PROFILE_CONFIG"
+  "UM_CLAIM"
+  "UM_CLAIM_BEHAVIOR"
+  "UM_DOMAIN"
+  "UM_ORG_USER_ASSOCIATION"
+  "UM_HYBRID_REMEMBER_ME"
+  "UM_UUID_DOMAIN_MAPPER"
+  "UM_GROUP_UUID_DOMAIN_MAPPER"
+  "UM_ACCOUNT_MAPPING"
+)
+
+# Step 1: Validate export file
+if [[ ! -f "$EXPORT_FILE" ]]; then
+  echo "Export file not found: $EXPORT_FILE"
+  exit 1
+fi
+
+# Step 2: Get available tables from PostgreSQL database
+echo "Fetching available tables from PostgreSQL database..."
+AVAILABLE_TABLES=$(psql -h "$DB_HOST" -p "$DB_PORT" -d "$DB_NAME" -U "$DB_USER" -t -c "SELECT tablename FROM pg_tables WHERE schemaname = 'public';")
+
+if [[ $? -ne 0 ]]; then
+  echo "Failed to fetch available tables. Please check database connection and credentials."
+  exit 1
+fi
+
+# Step 3: Filter TABLE_LIST to include only existing tables
+DELETE_ORDER=()
+for table in "${TABLE_LIST[@]}"; do
+  if echo "$AVAILABLE_TABLES" | grep -qw "$table"; then
+    DELETE_ORDER+=("$table")
+  fi
+done
+
+echo "Starting data deletion process..."
+
+# Step 4: Iterate through each tenant and execute delete queries
+while IFS=',' read -r TENANT_ID ORG_UUID; do
+  # Trim spaces
+  TENANT_ID=$(echo "$TENANT_ID" | xargs)
+  ORG_UUID=$(echo "$ORG_UUID" | xargs)
+
+  if [[ -n "$TENANT_ID" && -n "$ORG_UUID" ]]; then
+    echo "Processing TENANT_ID=$TENANT_ID, ORG_UUID=$ORG_UUID"
+
+    # Construct the deletion procedure
+    DELETE_PROCEDURE=""
+    for table in "${DELETE_ORDER[@]}"; do
+      if [[ "$table" == "UM_ORG_USER_ASSOCIATION" ]]; then
+        DELETE_PROCEDURE+="DELETE FROM $table WHERE UM_ORG_ID = '$ORG_UUID';"
+      elif [[ "$table" == UM_* ]]; then
+        DELETE_PROCEDURE+="DELETE FROM $table WHERE UM_TENANT_ID = $TENANT_ID;"
+      elif [[ "$table" == REG_* ]]; then
+        DELETE_PROCEDURE+="DELETE FROM $table WHERE REG_TENANT_ID = $TENANT_ID;"
+      fi
+    done
+
+    # Execute the delete procedure
+    echo "Executing deletion procedure on shared database for TENANT_ID=$TENANT_ID..."
+    psql -h "$DB_HOST" -p "$DB_PORT" -d "$DB_NAME" -U "$DB_USER" -c "$DELETE_PROCEDURE" -q > /dev/null 2>&1
+
+    # Check if the execution was successful
+    if [[ $? -eq 0 ]]; then
+      echo "Resources deleted for tenant ID $TENANT_ID with org ID $ORG_UUID." | tee -a "$SUMMARY_FILE"
+      echo "$TENANT_ID" >> "$SUCCESSFUL_DELETIONS_FILE"
+    else
+      FAILED_LOG="$LOG_DIR/failed_tenant_${TENANT_ID}.log"
+      echo "$DELETE_PROCEDURE" > "$FAILED_LOG"
+      echo "Failed to process tenant ID $TENANT_ID with org ID $ORG_UUID. Check log: $FAILED_LOG" | tee -a "$SUMMARY_FILE"
+    fi
+
+    echo "Completed deletion for TENANT_ID=$TENANT_ID."
+  else
+    echo "Skipping invalid or empty line: TENANT_ID=$TENANT_ID, ORG_UUID=$ORG_UUID"
+  fi
+done < "$EXPORT_FILE"
+
+echo "Data deletion process completed. Summary available at $SUMMARY_FILE."
+
+# Unset PGPASSWORD to avoid leaving it in the environment
+unset PGPASSWORD

--- a/7.0.0/postgresql/shared_db_cleanup.sh
+++ b/7.0.0/postgresql/shared_db_cleanup.sh
@@ -77,7 +77,7 @@ fi
 # Step 3: Filter TABLE_LIST to include only existing tables
 DELETE_ORDER=()
 for table in "${TABLE_LIST[@]}"; do
-  if echo "$AVAILABLE_TABLES" | grep -qw "$table"; then
+  if echo "$AVAILABLE_TABLES" | grep -qiw "$table"; then
     DELETE_ORDER+=("$table")
   fi
 done
@@ -86,9 +86,9 @@ echo "Starting data deletion process..."
 
 # Step 4: Iterate through each tenant and execute delete queries
 while IFS=',' read -r TENANT_ID ORG_UUID; do
-  # Trim spaces
-  TENANT_ID=$(echo "$TENANT_ID" | xargs)
-  ORG_UUID=$(echo "$ORG_UUID" | xargs)
+  # Trim and sanitize TENANT_ID, ORG_UUID
+  TENANT_ID=$(echo "$TENANT_ID" | xargs | sed 's/[^a-zA-Z0-9-]//g')
+  ORG_UUID=$(echo "$ORG_UUID" | xargs | sed 's/[^a-zA-Z0-9-]//g')
 
   if [[ -n "$TENANT_ID" && -n "$ORG_UUID" ]]; then
     echo "Processing TENANT_ID=$TENANT_ID, ORG_UUID=$ORG_UUID"

--- a/7.0.0/postgresql/shared_db_cleanup.sh
+++ b/7.0.0/postgresql/shared_db_cleanup.sh
@@ -12,6 +12,12 @@ LOG_DIR="$7"
 # Export PostgreSQL password to suppress password warnings
 export PGPASSWORD="$DB_PASSWORD"
 
+cleanup() {
+  unset PGPASSWORD
+}
+
+trap cleanup EXIT
+
 SUMMARY_FILE="$LOG_DIR/summary.log"
 SUCCESSFUL_DELETIONS_FILE="$LOG_DIR/successful_deletions.csv"
 
@@ -126,6 +132,3 @@ while IFS=',' read -r TENANT_ID ORG_UUID; do
 done < "$EXPORT_FILE"
 
 echo "Data deletion process completed. Summary available at $SUMMARY_FILE."
-
-# Unset PGPASSWORD to avoid leaving it in the environment
-unset PGPASSWORD


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

## Related issues

- https://github.com/wso2/product-is/issues/25490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added PostgreSQL database maintenance utilities for exporting tenant/org identifiers and cleaning tenant-scoped records across shared and identity databases.
  * Added validation and safety checks to compare exported “success” inputs before performing deletions.
* **Chores**
  * Automated cleanup now writes per-run summary logs and per-tenant failure logs to help track outcomes during batch operations.
* **Documentation**
  * Updated supported database guidance to include PostgreSQL for organization cleanup scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->